### PR TITLE
Initial xcconfig files

### DIFF
--- a/Common/Extension.xcconfig
+++ b/Common/Extension.xcconfig
@@ -1,0 +1,9 @@
+//
+// This file defines additional configuration options that are appropriate only for extensions.
+// This file is not standalone -- it is meant to be included into a configuration file for a
+// specific type of target.
+//
+
+// Disallows use of APIs that are not available to app extensions and linking to frameworks
+// that have not been built with this setting enabled.
+APPLICATION_EXTENSION_API_ONLY = YES

--- a/Common/Framework.xcconfig
+++ b/Common/Framework.xcconfig
@@ -1,0 +1,17 @@
+//
+// This file defines additional configuration options that are appropriate only for frameworks.
+// This file is not standalone -- it is meant to be included into a configuration file for a
+// specific type of target.
+//
+
+// Disallows use of APIs that are not available to app extensions and linking to frameworks
+// that have not been built with this setting enabled.
+APPLICATION_EXTENSION_API_ONLY = YES
+
+DYLIB_INSTALL_NAME_BASE = @rpath
+
+// Whether function calls should be position-dependent (should always be NO for library code)
+GCC_DYNAMIC_NO_PIC = NO
+
+// Prevents installing to the system install location
+SKIP_INSTALL = YES

--- a/Common/Project.xcconfig
+++ b/Common/Project.xcconfig
@@ -1,0 +1,153 @@
+//
+// This file defines common settings that should be enabled for every new project.
+// Typically, you want to use Debug, Release, or a similar variant instead.
+//
+
+// Disable legacy-compatible header searching
+ALWAYS_SEARCH_USER_PATHS = NO
+
+// Whether to warn when a floating-point value is used as a loop counter
+CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES
+
+// Whether to warn about use of rand() and random() being used instead of arc4random()
+CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES
+
+// Whether to warn about strcpy() and strcat()
+CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES
+
+// Whether to enable module imports
+CLANG_ENABLE_MODULES = YES
+
+// Enable ARC
+CLANG_ENABLE_OBJC_ARC = YES
+
+// Warn about implicit conversions to boolean values that are suspicious.
+// For example, writing 'if (foo)' with 'foo' being the name a function will trigger a warning.
+CLANG_WARN_BOOL_CONVERSION = YES
+
+// Warn about implicit conversions of constant values that cause the constant value to change,
+// either through a loss of precision, or entirely in its meaning.
+CLANG_WARN_CONSTANT_CONVERSION = YES
+
+// Whether to warn when overriding deprecated methods
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES
+
+// Warn about direct accesses to the Objective-C 'isa' pointer instead of using a runtime API.
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR
+
+// Warn about declaring the same method more than once within the same @interface.
+CLANG_WARN__DUPLICATE_METHOD_MATCH = YES
+
+// Warn about loop bodies that are suspiciously empty.
+CLANG_WARN_EMPTY_BODY = YES
+
+// Warn about implicit conversions between different kinds of enum values.
+// For example, this can catch issues when using the wrong enum flag as an argument
+// to a function or method.
+CLANG_WARN_ENUM_CONVERSION = YES
+
+// Whether to warn on implicit conversions between signed/unsigned types
+CLANG_WARN_IMPLICIT_SIGN_CONVERSION = NO
+
+// Warn about implicit conversions between pointers and integers.
+// For example, this can catch issues when one incorrectly intermixes using NSNumbers
+// and raw integers.
+CLANG_WARN_INT_CONVERSION = YES
+
+CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION = YES
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES
+
+// Don't warn about repeatedly using a weak reference without assigning the weak reference
+// to a strong reference. Too many false positives.
+CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = NO
+
+// Warn about classes that unintentionally do not subclass a root class (such as NSObject).
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR
+
+// Whether to warn on suspicious implicit conversions
+CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES
+
+// Warn about potentially unreachable code
+CLANG_WARN_UNREACHABLE_CODE = YES
+
+// The format of debugging symbols
+DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
+
+// Whether to require objc_msgSend to be cast before invocation
+ENABLE_STRICT_OBJC_MSGSEND = YES
+
+// Whether to enable exceptions for Objective-C
+GCC_ENABLE_OBJC_EXCEPTIONS = YES
+
+// Whether to generate debugging symbols
+GCC_GENERATE_DEBUGGING_SYMBOLS = YES
+
+// Whether to precompile the prefix header (if one is specified)
+GCC_PRECOMPILE_PREFIX_HEADER = YES
+
+// Whether to enable strict aliasing, meaning that two pointers of different types
+// (other than void * or any id type) cannot point to the same memory location
+GCC_STRICT_ALIASING = YES
+
+// Whether to warn about 64-bit values being implicitly shortened to 32 bits
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES
+
+// Whether to warn about fields missing from structure initializers
+// (only if designated initializers aren't used)
+GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES
+
+// Whether to warn about missing function prototypes
+GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES
+
+// Whether to warn about implicit conversions in the signedness of the type
+// a pointer is pointing to (e.g., 'int *' getting converted to 'unsigned int *')
+GCC_WARN_ABOUT_POINTER_SIGNEDNESS = YES
+
+// Whether to warn when the value returned from a function/method/block does not
+// match its return type
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR
+
+// Whether to warn on a class not implementing all the required methods of
+// a protocol it declares conformance to
+GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = YES
+
+// Whether to warn when switching on an enum value, and all possibilities are
+// not accounted for
+GCC_WARN_CHECK_SWITCH_STATEMENTS = YES
+
+// Whether to warn about the use of four-character constants
+GCC_WARN_FOUR_CHARACTER_CONSTANTS = YES
+
+// Whether to warn about an aggregate data type's initializer not being fully
+// bracketed (e.g., array initializer syntax)
+GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES
+
+// Whether to warn about missing braces or parentheses that make the meaning of
+// the code ambiguous
+GCC_WARN_MISSING_PARENTHESES = YES
+
+// Whether to warn about unsafe comparisons between values of different signedness
+GCC_WARN_SIGN_COMPARE = YES
+
+// Whether to warn about the arguments to printf-style functions not matching
+// the format specifiers
+GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES
+
+// Warn if a "@selector(...)" expression referring to an undeclared selector is found
+GCC_WARN_UNDECLARED_SELECTOR = YES
+
+// Warn if a variable might be clobbered by a setjmp call or if an automatic variable
+// is used without prior initialization.
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE
+
+// Whether to warn about static functions that are unused
+GCC_WARN_UNUSED_FUNCTION = YES
+
+// Whether to warn about labels that are unused
+GCC_WARN_UNUSED_LABEL = YES
+
+// Wether to warn about function parameters that are unused
+GCC_WARN_UNUSED_PARAMETER = YES
+
+// Whether to warn about variables that are never used
+GCC_WARN_UNUSED_VARIABLE = YES

--- a/Common/iOS.xcconfig
+++ b/Common/iOS.xcconfig
@@ -1,0 +1,17 @@
+//
+// This file defines additional configuration options that are appropriate only for iOS.
+// This file is not standalone -- it is meant to be included into a configuration file for a
+// specific type of target.
+//
+
+// Supported device families (1 is Phone, 2 is Pad, 3 is TV, 4 is Watch)
+TARGETED_DEVICE_FAMILY = 1,2
+
+// The base SDK to use (if no version is specified, the latest version is assumed)
+SDKROOT = iphoneos
+
+// Refine down supported platforms, in case we need to override Universal settings
+SUPPORTED_PLATFORMS = iphonesimulator iphoneos
+
+// With Xcode 7 code signing is available to everyone
+CODE_SIGN_IDENTITY = iPhone Developer

--- a/Common/macOSX.xcconfig
+++ b/Common/macOSX.xcconfig
@@ -1,0 +1,14 @@
+//
+// This file defines additional configuration options that are appropriate only for Mac OS X.
+// This file is not standalone -- it is meant to be included into a configuration file for a
+// specific type of target.
+//
+
+// The base SDK to use (if no version is specified, the latest version is assumed)
+SDKROOT = macosx
+
+// Refine down supported platforms, in case we need to override Universal settings
+SUPPORTED_PLATFORMS = macosx
+
+// Whether to combine multiple image resolutions into a multirepresentational TIFF
+COMBINE_HIDPI_IMAGES = YES

--- a/Common/tvOS.xcconfig
+++ b/Common/tvOS.xcconfig
@@ -1,0 +1,17 @@
+//
+// This file defines additional configuration options that are appropriate only for tvOS.
+// This file is not standalone -- it is meant to be included into a configuration file for a
+// specific type of target.
+//
+
+// Supported device families (1 is Phone, 2 is Pad, 3 is TV, 4 is Watch)
+TARGETED_DEVICE_FAMILY = 3
+
+// The base SDK to use (if no version is specified, the latest version is assumed)
+SDKROOT = appletvos
+
+// Refine down supported platforms, in case we need to override Universal settings
+SUPPORTED_PLATFORMS = appletvsimulator appletvos
+
+// With Xcode 7 code signing is available to everyone
+CODE_SIGN_IDENTITY = iPhone Developer

--- a/Common/watchOS.xcconfig
+++ b/Common/watchOS.xcconfig
@@ -1,0 +1,17 @@
+//
+// This file defines additional configuration options that are appropriate only for watchOS.
+// This file is not standalone -- it is meant to be included into a configuration file for a
+// specific type of target.
+//
+
+// Supported device families (1 is Phone, 2 is Pad, 3 is TV, 4 is Watch)
+TARGETED_DEVICE_FAMILY = 4
+
+// The base SDK to use (if no version is specified, the latest version is assumed)
+SDKROOT = watchos
+
+// Refine down supported platforms, in case we need to override Universal settings
+SUPPORTED_PLATFORMS = watchsimulator watchos
+
+// Code signing is required
+CODE_SIGN_IDENTITY = iPhone Developer

--- a/Project/Debug.xcconfig
+++ b/Project/Debug.xcconfig
@@ -1,0 +1,30 @@
+//
+// This file defines the base configuration for a Debug build of any project.
+// This should be set at the project level for the Debug configuration.
+//
+
+#include "../Common/Project.xcconfig"
+
+// The format of debugging symbols
+// Without dSYM speeds up development iteration
+DEBUG_INFORMATION_FORMAT = dwarf
+
+// Allow running automated tests
+ENABLE_TESTABILITY = YES
+
+// The optimization level (0, 1, 2, 3, s) for the produced binary
+GCC_OPTIMIZATION_LEVEL = 0
+
+// Whether to only build the active architecture
+ONLY_ACTIVE_ARCH = YES
+
+// Other flags to pass to the Swift compiler
+//
+// This enables conditional compilation with #if DEBUG
+OTHER_SWIFT_FLAGS = -D DEBUG
+
+// The optimization level (-Onone, -O, -Owholemodule) for the produced Swift binary
+SWIFT_OPTIMIZATION_LEVEL = -Onone
+
+// Whether to perform App Store validation checks
+VALIDATE_PRODUCT = NO

--- a/Project/Release.xcconfig
+++ b/Project/Release.xcconfig
@@ -1,0 +1,27 @@
+//
+// This file defines the base configuration for a Release build of any project.
+// This should be set at the project level for the Release configuration.
+//
+
+#include "../Common/Project.xcconfig"
+
+// The format of debugging symbols
+DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
+
+// Allow running automated tests
+ENABLE_TESTABILITY = NO
+
+// The optimization level (0, 1, 2, 3, s) for the produced binary
+GCC_OPTIMIZATION_LEVEL = s
+
+// Whether to only build the active architecture
+ONLY_ACTIVE_ARCH = NO
+
+// Whether to run the static analyzer with every build
+RUN_CLANG_STATIC_ANALYZER = YES
+
+// The optimization level (-Onone, -O, -Owholemodule) for the produced Swift binary
+SWIFT_OPTIMIZATION_LEVEL = -Owholemodule
+
+// Whether to perform App Store validation checks
+VALIDATE_PRODUCT = YES

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Base xcconfigs
+
+Using xcconfigs, instead of modifying settings in an Xcode project, is my preferred way configuring targets. They allow for reuse of settings across projects and targets. They also allow for standardization of settings for specific types of targets (eg. iOS app, tvOS app, Universal framework), which is purpose of this repository.
+
+By using the xcconfigs in this repository as a basis for your own xcconfigs (either via `#include` or copying) you should get a solid foundation for your project's and target's settings. The xcconfigs use a hierarchical structure to allow for easy maintainability.
+
+## Target Configurations
+
+For target level configurations there are the following base xcconfigs:
+
+- Applications
+    - iOS, Mac OS X, tvOS, and watchOS
+- Extensions
+    - iOS, Mac OS X, tvOS, and watchOS
+- Frameworks
+    - iOS, Mac OS X, tvOS, watchOS, and Universal
+- Tests
+    - iOS, Mac OS X, tvOS, and Universal
+    - _watchOS currently doesn't support tests_
+
+_Note:_ "Universal" above means having a single target that can compile for any of the other listed platforms.
+
+## Project Configurations
+
+For project level configurations there are the following base xcconfigs:
+
+- Debug
+- Release
+
+## Usage
+
+TODO _(Recommend submodule for integration. Describe normal `#include` usage. Describe normal project group setup for selection by Xcode.)_
+
+## Credits
+
+Inspired by [@jspahrsummers's](https://github.com/jspahrsummers/xcconfigs/pull/43) and [@mrackwitz's](https://github.com/mrackwitz/xcconfigs) xcconfigs. @samdmarshall's [unofficial guide to xcconfig files](http://pewpewthespells.com/blog/xcconfig_guide.html) was also very helpful.

--- a/Target/Universal/Framework.Universal.xcconfig
+++ b/Target/Universal/Framework.Universal.xcconfig
@@ -1,0 +1,33 @@
+//
+// Universal framework target settings
+//
+// Override SUPPORTED_PLATFORMS if you want a subset of platforms.
+//
+
+#include "../../Common/Framework.xcconfig"
+
+SUPPORTED_PLATFORMS = macosx iphonesimulator iphoneos watchos watchsimulator appletvos appletvsimulator
+
+
+// Dynamic linking uses different default copy paths
+LD_RUNPATH_SEARCH_PATHS[sdk=macosx*] = $(inherited) '@executable_path/../Frameworks' '@loader_path/Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=iphone*] = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=appletv*] = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=watch*] = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+
+
+// OSX-specific default settings
+FRAMEWORK_VERSION[sdk=macosx*] = A
+COMBINE_HIDPI_IMAGES = YES
+
+// iOS-specific default settings
+CODE_SIGN_IDENTITY[sdk=iphone*] = iPhone Developer
+TARGETED_DEVICE_FAMILY[sdk=iphone*] = 1,2
+
+// TV-specific default settings
+CODE_SIGN_IDENTITY[sdk=appletv*] = iPhone Developer
+TARGETED_DEVICE_FAMILY[sdk=appletv*] = 3
+
+// Watch-specific default settings
+CODE_SIGN_IDENTITY[sdk=watch*] = iPhone Developer
+TARGETED_DEVICE_FAMILY[sdk=watch*] = 4

--- a/Target/Universal/Tests.Universal.xcconfig
+++ b/Target/Universal/Tests.Universal.xcconfig
@@ -1,0 +1,17 @@
+//
+// Universal tests target settings
+//
+// Override SUPPORTED_PLATFORMS if you want a subset of platforms.
+//
+
+// Watch doesn't have XCTest currently
+SUPPORTED_PLATFORMS = macosx iphonesimulator iphoneos appletvos appletvsimulator
+
+// Platform specific version of XCTest
+FRAMEWORK_SEARCH_PATHS = $(inherited) '$(PLATFORM_DIR)/Developer/Library/Frameworks'
+
+// Dynamic linking uses different default copy paths
+LD_RUNPATH_SEARCH_PATHS[sdk=macosx*] = $(inherited) '@executable_path/../Frameworks' '@loader_path/../Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=iphone*] = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=appletv*] = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=watch*] = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'

--- a/Target/iOS/Application.iOS.xcconfig
+++ b/Target/iOS/Application.iOS.xcconfig
@@ -1,0 +1,5 @@
+
+#include "../../Common/iOS.xcconfig"
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) '@executable_path/Frameworks'

--- a/Target/iOS/Extension.iOS.xcconfig
+++ b/Target/iOS/Extension.iOS.xcconfig
@@ -1,0 +1,6 @@
+
+#include "../../Common/Extension.xcconfig"
+#include "../../Common/iOS.xcconfig"
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) '@executable_path/Frameworks' '@executable_path/../../Frameworks'

--- a/Target/iOS/Framework.iOS.xcconfig
+++ b/Target/iOS/Framework.iOS.xcconfig
@@ -1,0 +1,6 @@
+
+// Universal framework has all the paths set correctly
+#include "../Universal/Framework.Universal.xcconfig"
+
+// Refine down to iOS only
+#include "../../Common/iOS.xcconfig"

--- a/Target/iOS/Tests.iOS.xcconfig
+++ b/Target/iOS/Tests.iOS.xcconfig
@@ -1,0 +1,6 @@
+
+// Universal tests has all the paths set correctly
+#include "../Universal/Tests.Universal.xcconfig"
+
+// Refine down to iOS only
+#include "../../Common/iOS.xcconfig"

--- a/Target/macOSX/Application.macOSX.xcconfig
+++ b/Target/macOSX/Application.macOSX.xcconfig
@@ -1,0 +1,5 @@
+
+#include "../../Common/macOSX.xcconfig"
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) '@executable_path/../Frameworks'

--- a/Target/macOSX/Extension.macOSX.xcconfig
+++ b/Target/macOSX/Extension.macOSX.xcconfig
@@ -1,0 +1,6 @@
+
+#include "../../Common/Extension.xcconfig"
+#include "../../Common/macOSX.xcconfig"
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) '@executable_path/../Frameworks' '@executable_path/../../../../Frameworks'

--- a/Target/macOSX/Framework.macOSX.xcconfig
+++ b/Target/macOSX/Framework.macOSX.xcconfig
@@ -1,0 +1,6 @@
+
+// Universal framework has all the paths set correctly
+#include "../Universal/Framework.Universal.xcconfig"
+
+// Refine down to Mac OS X only
+#include "../../Common/macOSX.xcconfig"

--- a/Target/macOSX/Tests.macOSX.xcconfig
+++ b/Target/macOSX/Tests.macOSX.xcconfig
@@ -1,0 +1,6 @@
+
+// Universal tests has all the paths set correctly
+#include "../Universal/Tests.Universal.xcconfig"
+
+// Refine down to Mac OS X only
+#include "../../Common/macOSX.xcconfig"

--- a/Target/tvOS/Application.tvOS.xcconfig
+++ b/Target/tvOS/Application.tvOS.xcconfig
@@ -1,0 +1,5 @@
+
+#include "../../Common/tvOS.xcconfig"
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) '@executable_path/Frameworks'

--- a/Target/tvOS/Extension.tvOS.xcconfig
+++ b/Target/tvOS/Extension.tvOS.xcconfig
@@ -1,0 +1,6 @@
+
+#include "../../Common/Extension.xcconfig"
+#include "../../Common/tvOS.xcconfig"
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) '@executable_path/Frameworks' '@executable_path/../../Frameworks'

--- a/Target/tvOS/Framework.tvOS.xcconfig
+++ b/Target/tvOS/Framework.tvOS.xcconfig
@@ -1,0 +1,6 @@
+
+// Universal framework has all the paths set correctly
+#include "../Universal/Framework.Universal.xcconfig"
+
+// Refine down to tvOS only
+#include "../../Common/tvOS.xcconfig"

--- a/Target/tvOS/Tests.tvOS.xcconfig
+++ b/Target/tvOS/Tests.tvOS.xcconfig
@@ -1,0 +1,6 @@
+
+// Universal tests has all the paths set correctly
+#include "../Universal/Tests.Universal.xcconfig"
+
+// Refine down to tvOS only
+#include "../../Common/tvOS.xcconfig"

--- a/Target/watchOS/Application.watchOS.xcconfig
+++ b/Target/watchOS/Application.watchOS.xcconfig
@@ -1,0 +1,5 @@
+
+#include "../../Common/watchOS.xcconfig"
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) '@executable_path/Frameworks'

--- a/Target/watchOS/Extension.watchOS.xcconfig
+++ b/Target/watchOS/Extension.watchOS.xcconfig
@@ -1,0 +1,6 @@
+
+#include "../../Common/Extension.xcconfig"
+#include "../../Common/watchOS.xcconfig"
+
+// Where to find embedded frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) '@executable_path/Frameworks' '@executable_path/../../Frameworks'

--- a/Target/watchOS/Framework.watchOS.xcconfig
+++ b/Target/watchOS/Framework.watchOS.xcconfig
@@ -1,0 +1,6 @@
+
+// Universal framework has all the paths set correctly
+#include "../Universal/Framework.Universal.xcconfig"
+
+// Refine down to tvOS only
+#include "../../Common/tvOS.xcconfig"


### PR DESCRIPTION
Supports:
- Applications (iOS, Mac OS X, tvOS, and watchOS)
- Extensions (iOS, Mac OS X, tvOS, and watchOS)
- Frameworks (iOS, Mac OS X, tvOS, watchOS, and Universal)
- Tests (iOS, Mac OS X, tvOS, and Universal)

"Universal" above means also supporting one target that compiles for all the of other supported platforms (so all of them, except in the case of Tests, since it watchOS currently doesn't support tests).