### PR TITLE
Set COPY_PHASE_STRIP = NO

### DIFF
--- a/Common/Project.xcconfig
+++ b/Common/Project.xcconfig
@@ -70,6 +70,9 @@ CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES
 // Warn about potentially unreachable code
 CLANG_WARN_UNREACHABLE_CODE = YES
 
+// Don't try to strip included frameworks. With code signing, this no longer works anyway.
+COPY_PHASE_STRIP = NO
+
 // The format of debugging symbols
 DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
 


### PR DESCRIPTION
New Xcode templates have this as NO. This makes sense, becuase most of the things you would be trying to strip are now code signed and can't be anyway. If you don't want debug info in your included frameworks, use a non-debug build.