### PR TITLE
Remove code signing of iOS-based frameworks

### DIFF
--- a/Target/Universal/Framework.Universal.xcconfig
+++ b/Target/Universal/Framework.Universal.xcconfig
@@ -25,13 +25,10 @@ FRAMEWORK_VERSION[sdk=macosx*] = A
 COMBINE_HIDPI_IMAGES = YES
 
 // iOS-specific default settings
-CODE_SIGN_IDENTITY[sdk=iphone*] = iPhone Developer
 TARGETED_DEVICE_FAMILY[sdk=iphone*] = 1,2
 
 // TV-specific default settings
-CODE_SIGN_IDENTITY[sdk=appletv*] = iPhone Developer
 TARGETED_DEVICE_FAMILY[sdk=appletv*] = 3
 
 // Watch-specific default settings
-CODE_SIGN_IDENTITY[sdk=watch*] = iPhone Developer
 TARGETED_DEVICE_FAMILY[sdk=watch*] = 4


### PR DESCRIPTION
As of Xcode 8 this is no longer required.